### PR TITLE
Feature/#37 게시물 단건 조회 시 댓글 리스트가 생성시간 오름차순 정렬이 되지않는 문제

### DIFF
--- a/src/main/java/com/mju_lion/letter/repository/CommentRepository.java
+++ b/src/main/java/com/mju_lion/letter/repository/CommentRepository.java
@@ -11,6 +11,6 @@ import java.util.List;
 import java.util.UUID;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
-    List<Comment> findByBoardId(UUID boardId);
+    List<Comment> findAllByBoardIdOrderByCreatedAtAsc(UUID boardId);
     Page<Comment> findByBoard(Board board, Pageable pageable);
 }

--- a/src/main/java/com/mju_lion/letter/service/BoardService.java
+++ b/src/main/java/com/mju_lion/letter/service/BoardService.java
@@ -72,7 +72,7 @@ public class BoardService {
         Board board = findExistingBoard(boardId);
 
         // 게시물에 달린 댓글리스트
-        List<Comment> commentList = commentRepository.findByBoardId(boardId);
+        List<Comment> commentList = commentRepository.findAllByBoardIdOrderByCreatedAtAsc(boardId);
 
         return BoardResponseData.builder()
                 .board(board)


### PR DESCRIPTION
## Description
게시물 단건 조회 시 댓글 리스트가 생성시간 오름차순 정렬이 되지않는 문제
게시물 단건 조회 response에 댓글 리스트가 생성 순이 아닌 무작위로 불러와지는 문제
## Changes
### CommentRepository 메서드 수정
- [x] CommentRepository
### BoardService getBoardById 로직 수정
- [x] BoardService
## Additional context

closes #37 